### PR TITLE
Add Debian 8.0 (jessie) MariaDB fingerprint

### DIFF
--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -679,6 +679,20 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
   </fingerprint>
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~jessie(?:-log)?$" flags="REG_ICASE">
+    <description>MariaDB MariaDB on Debian 8.0 (jessie)</description>
+    <example service.version="5.5.37">5.5.37-MariaDB-1~jessie-log</example>
+    <example service.version="10.0.11">10.0.11-MariaDB-1~jessie-log</example>
+    <example service.version="10.0.14">5.5.5-10.0.14-MariaDB-1~jessie-log</example>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.vendor" value="MariaDB"/>
+    <param pos="0" name="service.family" value="MySQL"/>
+    <param pos="0" name="service.product" value="MariaDB"/>
+    <param pos="0" name="os.vendor" value="Debian"/>
+   <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="8.0"/>
+  </fingerprint>
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~wheezy(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Debian 7.0 (wheezy)</description>
     <example service.version="5.5.37">5.5.37-MariaDB-1~wheezy-log</example>


### PR DESCRIPTION
Pull request to detect MariaDB on Debian Jessie, as per the current official Docker container from Docker Hub.